### PR TITLE
fix: avoid duplicate policy evaluation

### DIFF
--- a/src/core/defaultEvaluator.ts
+++ b/src/core/defaultEvaluator.ts
@@ -31,15 +31,10 @@ export function defaultPolicyEvaluator(_logger: ILogger): PolicyEvaluator {
       resource,
       context,
     });
-    // Flatten all policies from user and roles
+    // Flatten policies and remove duplicates to avoid evaluating the same policy twice
+    // (e.g. a policy attached directly to the user and through a role)
     const allPolicies = [
-      ...policies,
-      ...roles.flatMap(
-        (r) =>
-          r.policyIds
-            .map((pid) => policies.find((p) => p.id === pid))
-            .filter(Boolean) as Policy[]
-      ),
+      ...new Map(policies.map((p) => [p.id, p])).values(),
     ];
     const trace: {
       checkedPolicies: string[];

--- a/tests/defaultEvaluator.spec.ts
+++ b/tests/defaultEvaluator.spec.ts
@@ -55,6 +55,20 @@ describe('defaultPolicyEvaluator', () => {
     expect(result.trace.reason).toMatch(/No matching policy/);
   });
 
+  it('should not evaluate the same policy more than once', async () => {
+    const result = await evaluator(
+      user,
+      'delete',
+      'doc:1',
+      {},
+      [allowPolicy],
+      [role],
+      defaultConditionOperators
+    );
+    const occurrences = result.trace.checkedPolicies.filter((id) => id === 'p1');
+    expect(occurrences).toHaveLength(1);
+  });
+
   it('should deny when explicit deny policy matches', async () => {
     const result = await evaluator(
       user,


### PR DESCRIPTION
## Summary
- avoid evaluating duplicate policies in default evaluator
- add regression test for policy deduplication

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f2d9004b8832c83e7c8936acda6a7