### PR TITLE
test: assert AccessCondition failure

### DIFF
--- a/src/decorators/accessControl.ts
+++ b/src/decorators/accessControl.ts
@@ -139,10 +139,10 @@ export function AccessCondition(
 ): MethodDecorator {
   return (target, propertyKey, descriptor: PropertyDescriptor) => {
     const original = descriptor.value;
-    descriptor.value = function (this: any, ...args: any[]) {
+    descriptor.value = async function (this: any, ...args: any[]) {
       if (!condition(this.user, ...args))
         throw new Error("Access denied: condition failed");
-      return original.apply(this, args);
+      return await original.apply(this, args);
     };
     return descriptor;
   };

--- a/tests/accessControl-extended.spec.ts
+++ b/tests/accessControl-extended.spec.ts
@@ -145,15 +145,7 @@ describe("AccessControl and related decorators", () => {
       }
     }
     const f = new Fail();
-    try {
-      await t.foo();
-    } catch (error) {
-      if (error instanceof Error) {
-        expect(error.message).toMatch(/condition failed/);
-      } else {
-        fail(error);
-      }
-    }
+    await expect(f.foo()).rejects.toThrow(/condition failed/);
   });
 
 


### PR DESCRIPTION
## Summary
- assert AccessCondition failure using jest's `rejects.toThrow`
- make `AccessCondition` decorator async so failures reject the returned promise

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f2f2d52b4832cba22bc322db9be8a