### PR TITLE
feat: add YAML storage adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Supports policies, roles, decorators, adapters, and rich evaluation context beca
 ## Features
 - **AWS IAM-inspired**: Users, roles, policies, statements, actions, resources, conditions, effects (allow/deny, mostly deny)
 - **TypeScript-first**: Strict types, generics, and type-safe APIs (because you can't be trusted)
-- **Pluggable storage**: In-memory, JSON file, and custom adapters for your ever-changing stack
+- **Pluggable storage**: In-memory, JSON/YAML file, and custom adapters for your ever-changing stack
 - **Asynchronous evaluation**: Promise-based, always
 - **Rich decision context**: Not just boolean, but evaluation trace, matched policy/statement, etc.
 - **Decorators**: For route/method-level access control, with parameterized and composable support (so you can blame the decorator)
@@ -183,7 +183,7 @@ console.log(result.decision); // true
 ## Project Roadmap
 - [x] **Core IAM Engine**: Type-safe, extensible, and async policy evaluation
 - [x] **Policy, Role, User Model**: AWS IAM-inspired, with flat roles and explicit policy attachment
-- [x] **In-Memory & JSON Adapters**: Pluggable storage, ready for custom and RDBMS adapters
+- [x] **In-Memory, JSON & YAML Adapters**: Pluggable storage, ready for custom and RDBMS adapters
 - [x] **Rich Decorator Suite**: `@AccessControl`, `@RequireRole`, `@RequirePolicy`, `@AllowActions`, `@DenyActions`, `@AccessCondition`, `@LogAccess`
 - [x] **Role Assignment Utilities**: Assign/unassign roles to users
 - [x] **Serialization**: Import/export for policies, roles, etc.
@@ -221,7 +221,7 @@ console.log(result.decision); // true
 ```
 ├── src/
 │   ├── core/           # IAM engine, evaluators, logger, storage
-│   ├── adapters/       # In-memory, JSON
+│   ├── adapters/       # In-memory, JSON, YAML
 │   ├── decorators/     # Access control decorators
 │   ├── types/          # Entities, decision context, etc.
 │   └── utils/          # Role assignment, serialization

--- a/src/adapters/yamlFileAdapter.ts
+++ b/src/adapters/yamlFileAdapter.ts
@@ -1,0 +1,126 @@
+/**
+ * YAML file storage adapter (skeleton)
+ * @packageDocumentation
+ */
+import type { User, Role, Policy } from "../types/entities.js";
+import type { IAMStorage } from "../core/storage.js";
+import { promises as fs } from "fs";
+import { load, dump } from "js-yaml";
+
+export interface YAMLFileAdapterOptions {
+  filePath: string;
+}
+
+/**
+ * YAML file storage adapter implementing IAMStorage
+ */
+export class YAMLFileAdapter implements IAMStorage {
+  private filePath: string;
+  private data: { users: User[]; roles: Role[]; policies: Policy[] } = {
+    users: [],
+    roles: [],
+    policies: [],
+  };
+  private loaded = false;
+
+  constructor(options: YAMLFileAdapterOptions) {
+    this.filePath = options.filePath;
+  }
+
+  private async load() {
+    if (this.loaded) return;
+    try {
+      const raw = await fs.readFile(this.filePath, "utf-8");
+      const parsed = load(raw) as any;
+      if (parsed && typeof parsed === "object") {
+        this.data = parsed as { users: User[]; roles: Role[]; policies: Policy[] };
+      } else {
+        this.data = { users: [], roles: [], policies: [] };
+      }
+    } catch {
+      this.data = { users: [], roles: [], policies: [] };
+    }
+    this.loaded = true;
+  }
+  private async save() {
+    await fs.writeFile(this.filePath, dump(this.data), "utf-8");
+  }
+
+  async getUser(id: string): Promise<User | undefined> {
+    await this.load();
+    return this.data.users.find((u) => u.id === id);
+  }
+  async getUsers(ids: string[]): Promise<User[]> {
+    await this.load();
+    return this.data.users.filter((u) => ids.includes(u.id));
+  }
+  async *getAllUsers(): AsyncIterable<User> {
+    await this.load();
+    for (const user of this.data.users) yield user;
+  }
+
+  async getRole(id: string): Promise<Role | undefined> {
+    await this.load();
+    return this.data.roles.find((r) => r.id === id);
+  }
+  async getRoles(ids: string[]): Promise<Role[]> {
+    await this.load();
+    return this.data.roles.filter((r) => ids.includes(r.id));
+  }
+  async *getAllRoles(): AsyncIterable<Role> {
+    await this.load();
+    for (const role of this.data.roles) yield role;
+  }
+
+  async getPolicy(id: string): Promise<Policy | undefined> {
+    await this.load();
+    return this.data.policies.find((p) => p.id === id);
+  }
+  async getPolicies(ids: string[]): Promise<Policy[]> {
+    await this.load();
+    return this.data.policies.filter((p) => ids.includes(p.id));
+  }
+  async *getAllPolicies(): AsyncIterable<Policy> {
+    await this.load();
+    for (const policy of this.data.policies) yield policy;
+  }
+
+  async saveUser(user: User): Promise<void> {
+    await this.load();
+    const idx = this.data.users.findIndex((u) => u.id === user.id);
+    if (idx >= 0) this.data.users[idx] = user;
+    else this.data.users.push(user);
+    await this.save();
+  }
+  async saveRole(role: Role): Promise<void> {
+    await this.load();
+    const idx = this.data.roles.findIndex((r) => r.id === role.id);
+    if (idx >= 0) this.data.roles[idx] = role;
+    else this.data.roles.push(role);
+    await this.save();
+  }
+  async savePolicy(policy: Policy): Promise<void> {
+    await this.load();
+    const idx = this.data.policies.findIndex((p) => p.id === policy.id);
+    if (idx >= 0) this.data.policies[idx] = policy;
+    else this.data.policies.push(policy);
+    await this.save();
+  }
+
+  async deleteUser(id: string): Promise<void> {
+    await this.load();
+    this.data.users = this.data.users.filter((u) => u.id !== id);
+    await this.save();
+  }
+  async deleteRole(id: string): Promise<void> {
+    await this.load();
+    this.data.roles = this.data.roles.filter((r) => r.id !== id);
+    await this.save();
+  }
+  async deletePolicy(id: string): Promise<void> {
+    await this.load();
+    this.data.policies = this.data.policies.filter((p) => p.id !== id);
+    await this.save();
+  }
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 
 export * from "./adapters/inMemoryAdapter.js";
 export * from "./adapters/jsonFileAdapter.js";
+export * from "./adapters/yamlFileAdapter.js";
 
 export * from "./core/defaultEvaluator.js";
 export * from "./core/evaluator.js";

--- a/tests/yamlFileAdapter.spec.ts
+++ b/tests/yamlFileAdapter.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for YAMLFileAdapter
+ */
+import { YAMLFileAdapter } from '../src/adapters/yamlFileAdapter';
+import type { User, Role, Policy } from '../src/types/entities';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { dump } from 'js-yaml';
+
+describe('YAMLFileAdapter', () => {
+  const user: User = { id: 'u1', roleIds: ['r1'], policyIds: ['p1'] };
+  const role: Role = { id: 'r1', name: 'role', policyIds: ['p1'] };
+  const policy: Policy = { id: 'p1', name: 'policy', statements: [] };
+  let adapter: YAMLFileAdapter;
+  let tmpPath: string;
+
+  beforeEach(async () => {
+    tmpPath = join(__dirname, 'iam-yaml-test.yaml');
+    const content = dump({ users: [user], roles: [role], policies: [policy] });
+    await fs.writeFile(tmpPath, content, 'utf-8');
+    adapter = new YAMLFileAdapter({ filePath: tmpPath });
+  });
+  afterEach(async () => {
+    await fs.unlink(tmpPath).catch(() => {});
+  });
+
+  it('should get user by id', async () => {
+    expect(await adapter.getUser('u1')).toEqual(user);
+    expect(await adapter.getUser('nope')).toBeUndefined();
+  });
+
+  it('should get users by ids', async () => {
+    expect(await adapter.getUsers(['u1'])).toEqual([user]);
+    expect(await adapter.getUsers(['nope'])).toEqual([]);
+  });
+
+  it('should get all users (async iterable)', async () => {
+    const users: User[] = [];
+    for await (const u of adapter.getAllUsers()) users.push(u);
+    expect(users).toEqual([user]);
+  });
+
+  it('should get role by id', async () => {
+    expect(await adapter.getRole('r1')).toEqual(role);
+    expect(await adapter.getRole('nope')).toBeUndefined();
+  });
+
+  it('should get roles by ids', async () => {
+    expect(await adapter.getRoles(['r1'])).toEqual([role]);
+    expect(await adapter.getRoles(['nope'])).toEqual([]);
+  });
+
+  it('should get all roles (async iterable)', async () => {
+    const roles: Role[] = [];
+    for await (const r of adapter.getAllRoles()) roles.push(r);
+    expect(roles).toEqual([role]);
+  });
+
+  it('should get policy by id', async () => {
+    expect(await adapter.getPolicy('p1')).toEqual(policy);
+    expect(await adapter.getPolicy('nope')).toBeUndefined();
+  });
+
+  it('should get policies by ids', async () => {
+    expect(await adapter.getPolicies(['p1'])).toEqual([policy]);
+    expect(await adapter.getPolicies(['nope'])).toEqual([]);
+  });
+
+  it('should get all policies (async iterable)', async () => {
+    const policies: Policy[] = [];
+    for await (const p of adapter.getAllPolicies()) policies.push(p);
+    expect(policies).toEqual([policy]);
+  });
+
+  it('should save and update user', async () => {
+    const u2: User = { id: 'u2', roleIds: [], policyIds: [] };
+    await adapter.saveUser(u2);
+    expect(await adapter.getUser('u2')).toEqual(u2);
+    const updated = { ...u2, roleIds: ['r1'] };
+    await adapter.saveUser(updated);
+    expect(await adapter.getUser('u2')).toEqual(updated);
+  });
+
+  it('should save and update role', async () => {
+    const r2: Role = { id: 'r2', name: 'r2', policyIds: [] };
+    await adapter.saveRole(r2);
+    expect(await adapter.getRole('r2')).toEqual(r2);
+    const updated = { ...r2, name: 'updated' };
+    await adapter.saveRole(updated);
+    expect(await adapter.getRole('r2')).toEqual(updated);
+  });
+
+  it('should save and update policy', async () => {
+    const p2: Policy = { id: 'p2', name: 'p2', statements: [] };
+    await adapter.savePolicy(p2);
+    expect(await adapter.getPolicy('p2')).toEqual(p2);
+    const updated = { ...p2, name: 'updated' };
+    await adapter.savePolicy(updated);
+    expect(await adapter.getPolicy('p2')).toEqual(updated);
+  });
+
+  it('should delete user', async () => {
+    await adapter.deleteUser('u1');
+    expect(await adapter.getUser('u1')).toBeUndefined();
+  });
+
+  it('should delete role', async () => {
+    await adapter.deleteRole('r1');
+    expect(await adapter.getRole('r1')).toBeUndefined();
+  });
+
+  it('should delete policy', async () => {
+    await adapter.deletePolicy('p1');
+    expect(await adapter.getPolicy('p1')).toBeUndefined();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add YAML file storage adapter implementing IAMStorage
- expose YAMLFileAdapter from package entrypoint
- document YAML storage option and project structure
- cover YAMLFileAdapter with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f32446170832c9830004e14a96d39